### PR TITLE
Unaligned loads are UB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
 UNAME_S := $(shell uname -s)
 
 CXX              := clang++
+# Add -fsanitize=undefined for UBSAN.
 COMPILER_OPTIONS := \
 	-std=c++1z -stdlib=libc++ -O3 -g                           \
 	-fPIC -fexceptions -ferror-limit=1 -fno-omit-frame-pointer \
 	-Wall -Wpedantic                                           \
+	-DGIPFELI_NO_UNALIGNED                                     \
 	-DNDEBUG -Iinclude
 
 TEST_TRANSLATION_UNITS    := $(wildcard */*_test.cc)
@@ -16,11 +18,17 @@ ifeq ($(UNAME_S),Darwin)
     COMPILER_OPTIONS += -mmacosx-version-min=10.11 -arch x86_64
 endif
 
-all: $(LIBRARY_OBJECTS)
+all: library
+
+library: $(LIBRARY_OBJECTS)
 	ar -rcs libgipfeli.a $^
 
 clean:
-	rm -f src/*.o
+	rm -f src/*.o *.a gipfeli_test
+
+test: $(TEST_OBJECTS) library
+	$(CXX) -o gipfeli_test $(TEST_OBJECTS) $(COMPILER_OPTIONS) -L. -lgipfeli -lsupc++ -lc++
+
 
 %.o: %.cc
 	$(CXX) -c -o $@ $< $(COMPILER_OPTIONS)

--- a/src/gipfeli_test.cc
+++ b/src/gipfeli_test.cc
@@ -93,7 +93,23 @@ bool TestFile(const string& label, const string& filename,
   string uncompressed;
   ResetTimer();
   bool success = compressor->Uncompress(compressed, &uncompressed);
+  if (!success) {
+    cout << "Uncompress failed\n";
+  }
   *uncompression_time = GetElapsedTime();
+
+  if (original.size() == uncompressed.size()) {
+    for (size_t i = 0; i < original.size(); ++i) {
+      if (original[i] != uncompressed[i]) {
+        cout << "Difference at position " << i << " of " << original.size()
+             << ", " << original[i] << " vs " << uncompressed[i] << "\n";
+        break;
+      }
+    }
+  } else {
+    cout << "Size mismatch: " << original.size() << " vs. "
+         << uncompressed.size() << "\n";
+  }
 
   return success && (original == uncompressed);
 }


### PR DESCRIPTION
And apparently they stopped working somewhere between Clang 17 and Clang 20.

Also, since there is a test we might as well have a rule to build it.